### PR TITLE
docs: Fix simple typo, dependecy -> dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -260,7 +260,7 @@ and update CHANGELOG.rst.
 .. note::
 
     As to rnd_requirements.txt, usually, it is created when a dependent
-    library is not released. Once the dependecy is installed
+    library is not released. Once the dependency is installed
     (will be released), the future
     version of the dependency in the requirements.txt will be valid.
 


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `dependency` rather than `dependecy`.

